### PR TITLE
Enforce the 64 character limit and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository contains snippets for the ably.com homepage as required by [SDK-
 
 To add a new set of snippets create a top level directory in this repository named after the language the snippets are for and add the snippets in that directory.
 
+Please use the [JavaScript snippets](/javascript) as a reference for other languages.
 
 Regarding the max practical width in the design, this is the guideline
 

--- a/README.md
+++ b/README.md
@@ -8,23 +8,6 @@ To add a new set of snippets create a top level directory in this repository nam
 
 Please use the [JavaScript snippets](/javascript) as a reference for other languages.
 
-Regarding the max practical width in the design, this is the guideline
+The recommended maximum length for each line of code in a snippet is 60 characters to fit nicely within the homepage design, but the absolute maximum length is 64 characters to avoid wrapping to the next line.
 
-- the absolute max-width before the code will wrap is 64 characters
-- the recommended length is 60 characters
-- ATM the vertical line count is 5, before a scrollbar appears (subject to change)
-
-for this example .... extract the Ojbect literal
-
-**from**
-```
-final channel = ably.channels.get('doc:mars-launch-plan');
-await channel.publish('update', {'pos': chatAt, 'insert': 'Send Grimes first'});
-```
-**to**
-
-```
-final channel = ably.channels.get('doc:mars-launch-plan');
-const options = {'pos': chatAt, 'insert': 'Send Grimes first'};
-await channel.publish('update', options);
-```
+The recommended maximum number of lines in a snippet is 5 to avoid a scrollbar appearing, but this is subject to change.

--- a/javascript/gps-pub.js
+++ b/javascript/gps-pub.js
@@ -1,2 +1,3 @@
 const channel = ably.channels.get('driver:elon');
-channel.publish('position', { lat: lat, long: long, bearing: 'nw' });
+const msg = { lat: lat, long: long, bearing: 'nw' };
+channel.publish('position', msg);

--- a/javascript/multi-user-pub.js
+++ b/javascript/multi-user-pub.js
@@ -1,2 +1,3 @@
 const channel = ably.channels.get('doc:mars-launch-plan');
-channel.publish('update', { pos: charAt, insert: 'Send Grimes first' });
+const msg = { pos: charAt, insert: 'Send Grimes first' };
+channel.publish('update', msg);


### PR DESCRIPTION
This updates the JavaScript snippet to enforce the 64 character line length limit, and updates the recommendation text in the README.