### PR TITLE
Proposal: Use MQTT for both pub and sub

### DIFF
--- a/javascript/iot-pub.js
+++ b/javascript/iot-pub.js
@@ -1,2 +1,4 @@
-const channel = ably.channels.get('device:thermostat:bedroom');
-channel.publish('action', { type: 'temperature', value: 70 });
+mqttClient.on('connect', function() {
+  const measurement = { type: 'temperature', value: 70 }
+  mqttClient.publish('device:thermostat:bedroom', measurement);
+});


### PR DESCRIPTION
Paddy looked at the code samples and pointed out that the device publishing measurements, is likely to be an IoT device, and thus probably use an MQTT client.  Should we consider changing all IoT examples to use an MQTT client for both pub & sub.

Do you think this approach is correct?  If so, can we ask others to do PRs to change this for other languages?