### PR TITLE
[FIX] Add semicolon to JS Pub IoT snippet

### DIFF
--- a/javascript/iot-pub.js
+++ b/javascript/iot-pub.js
@@ -1,4 +1,4 @@
 mqttClient.on('connect', function() {
-  const measurement = { type: 'temperature', value: 70 }
+  const measurement = { type: 'temperature', value: 70 };
   mqttClient.publish('device:thermostat:bedroom', measurement);
 });


### PR DESCRIPTION
Quick fix, we discovered a missing semicolon while updating the code explorer.
this PR fixed that.